### PR TITLE
Address Nextjs build error

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -7,7 +7,7 @@
   ],
   "rules": {
     "eqeqeq": "error",
-    "prettier/prettier": ["warn", { "endOfLine": "auto" }],
+    "prettier/prettier": "warn",
     "space-before-function-paren": ["error", {
       "anonymous": "always",
       "named": "never",

--- a/client/app/ClientPageExample/page.tsx
+++ b/client/app/ClientPageExample/page.tsx
@@ -16,8 +16,8 @@ const PageOneExample = () => {
     <div>
       <h1>This is the /ClientPageExample route</h1>
       <h1>
-        This is a client rendered page, because it does have 'use client' at the top
-        of this file
+        This is a client rendered page, because it does have &#39use client&#39 at
+        the top of this file
       </h1>
     </div>
   )

--- a/client/app/ClientPageExample/page.tsx
+++ b/client/app/ClientPageExample/page.tsx
@@ -12,13 +12,13 @@ const PageOneExample = () => {
     ExampleAPIRoute()
   }, [])
 
+  const h1Text =
+    "This is a client rendered page, because it does have 'use client' at the the top of this file"
+
   return (
     <div>
       <h1>This is the /ClientPageExample route</h1>
-      <h1>
-        This is a client rendered page, because it does have &#39use client&#39 at
-        the top of this file
-      </h1>
+      <h1>{h1Text}</h1>
     </div>
   )
 }

--- a/client/app/PageOneExample/page.tsx
+++ b/client/app/PageOneExample/page.tsx
@@ -3,7 +3,7 @@ const PageOneExample = () => {
     <div>
       <h1>This is the /PageOneExample route</h1>
       <h1>
-        This is a server rendered page, because it doesn't have 'use client' at the
+        This is a server rendered page, because it doesn$#39t have &#39use client#&39
         top of this file
       </h1>
     </div>

--- a/client/app/PageOneExample/page.tsx
+++ b/client/app/PageOneExample/page.tsx
@@ -1,11 +1,10 @@
 const PageOneExample = () => {
+  const h1Text =
+    "This is a server rendered page, because it doesn't have 'use client' this file"
   return (
     <div>
       <h1>This is the /PageOneExample route</h1>
-      <h1>
-        This is a server rendered page, because it doesn$#39t have &#39use client#&39
-        top of this file
-      </h1>
+      <h1>{h1Text}</h1>
     </div>
   )
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,7 +7,6 @@
       "name": "chat-app",
       "dependencies": {
         "@microsoft/signalr": "^7.0.4",
-        "@types/signalr": "^2.4.0",
         "autoprefixer": "^10.4.13",
         "lint-staged": "^13.1.0",
         "next": "^13.1.1",
@@ -21,6 +20,7 @@
         "@types/node": "^18.11.18",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.10",
+        "@types/signalr": "^2.4.0",
         "@types/stripe-v3": "^3.1.27",
         "@typescript-eslint/eslint-plugin": "^5.48.0",
         "eslint": "^8.28.0",
@@ -426,6 +426,7 @@
       "version": "3.5.16",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.16.tgz",
       "integrity": "sha512-bsI7y4ZgeMkmpG9OM710RRzDFp+w4P1RGiIt30C1mSBT+ExCleeh4HObwgArnDFELmRrOpXgSYN9VF1hj+f1lw==",
+      "dev": true,
       "dependencies": {
         "@types/sizzle": "*"
       }
@@ -490,6 +491,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/signalr/-/signalr-2.4.0.tgz",
       "integrity": "sha512-ja8OC5IWKZTEx49bM/j2M9SHLZCw0oAflEW9WqBvD2tf4WWTcBFUcaCC3ohwee7Nwd0QuOGi3gsJZ+GDifCIMw==",
+      "dev": true,
       "dependencies": {
         "@types/jquery": "*"
       }
@@ -497,7 +499,8 @@
     "node_modules/@types/sizzle": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
     },
     "node_modules/@types/stripe-v3": {
       "version": "3.1.28",


### PR DESCRIPTION
- The build was failing to compile. It was not happy with single quotes in the h1 tags of ./app/ClientPageExample and ./app/PageOneExample. 

- Replaced single quotes with the HTML entity '&#39'.  