### PR TITLE
View available chat rooms

### DIFF
--- a/client/app/chat-room/[slug]/page.tsx
+++ b/client/app/chat-room/[slug]/page.tsx
@@ -1,4 +1,5 @@
 // This is a server only page. Must import client components to use hooks.
+import AvailableChatRooms from '@components/AvailableChatRooms/AvailableChatRooms'
 import ChatRoomExample from '@components/ChatRoomExample/ChatRoomExample'
 
 export interface Props {
@@ -14,6 +15,8 @@ export default async function ChatRoomSlug(props: Props) {
     <div>
       <h1>Welcome to page ${params.page}</h1>
       <ChatRoomExample page={params.page} />
+
+      <AvailableChatRooms />
     </div>
   )
 }

--- a/client/app/chat-room/[slug]/page.tsx
+++ b/client/app/chat-room/[slug]/page.tsx
@@ -1,5 +1,4 @@
 // This is a server only page. Must import client components to use hooks.
-import AvailableChatRooms from '@components/AvailableChatRooms/AvailableChatRooms'
 import ChatRoomExample from '@components/ChatRoomExample/ChatRoomExample'
 
 export interface Props {
@@ -15,8 +14,6 @@ export default async function ChatRoomSlug(props: Props) {
     <div>
       <h1>Welcome to page ${params.page}</h1>
       <ChatRoomExample page={params.page} />
-
-      <AvailableChatRooms />
     </div>
   )
 }

--- a/client/app/chat-room/page.tsx
+++ b/client/app/chat-room/page.tsx
@@ -1,10 +1,7 @@
-import AvailableChatRooms from "@components/AvailableChatRooms/AvailableChatRooms"
-
 const ChatRoomSlug = () => {
   return (
     <div>
-      {/* <h1>Welcome to page ChatRoomSlug</h1> */}
-      <AvailableChatRooms />
+      <h1>Welcome to page ChatRoomSlug</h1>
     </div>
   )
 }

--- a/client/app/profile/page.tsx
+++ b/client/app/profile/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import AvailableChatRooms from '@components/AvailableChatRooms/AvailableChatRooms'
 import withAuth from 'hooks/WithAuth'
 import { UserDTO } from 'services/authentication/types/authentication.type'
 
@@ -7,6 +8,7 @@ const Profile = (props: { user: UserDTO }) => {
     <div>
       <h1>Your Profile?</h1>
       <h2>{JSON.stringify(props?.user?.username)}</h2>
+      <AvailableChatRooms />
     </div>
   )
 }

--- a/client/app/profile/page.tsx
+++ b/client/app/profile/page.tsx
@@ -2,13 +2,15 @@
 import AvailableChatRooms from '@components/AvailableChatRooms/AvailableChatRooms'
 import withAuth from 'hooks/WithAuth'
 import { UserDTO } from 'services/authentication/types/authentication.type'
+import styles from '@styles/Register.module.scss'
 
 const Profile = (props: { user: UserDTO }) => {
+  const username = props?.user?.username
   return (
-    <div>
-      <h1>Your Profile?</h1>
-      <h2>{JSON.stringify(props?.user?.username)}</h2>
-      <AvailableChatRooms />
+    <div className={styles.pageLayout}>
+      <h2>Hi {username}</h2>
+      <h3>Join a chat room to get chatting.</h3>
+      <AvailableChatRooms name={username} />
     </div>
   )
 }

--- a/client/components/AvailableChatRooms/AvailableChatRooms.module.scss
+++ b/client/components/AvailableChatRooms/AvailableChatRooms.module.scss
@@ -1,18 +1,5 @@
 @use "variables.module.scss" as v;
 
-
-// h2 {
-//     font-size: v.$base-font-size;
-//     text-align: center;
-//     color: v.$primary-dark;
-//     margin-bottom: 1rem;
-// }
-
-// a {
-//     text-decoration: none;
-//     color: v.$neutral-900;
-// }
-
 .wrapper {
     text-align: center;
     
@@ -57,7 +44,6 @@
             width: 100%;
     
             .roomInfo {
-                padding: 1rem;
                 background-color: v.$neutral-200;
                 border: 2px solid v.$primary-light;
                 border-radius: 15px;
@@ -65,6 +51,11 @@
                 
                 &:hover {
                     box-shadow: 0px 0px 10px v.$neutral-500;
+                }
+
+                a {
+                    display: block;
+                    padding: 1rem;
                 }
             }
         }
@@ -89,7 +80,6 @@
             .createChatLink {
                 color: v.$neutral-100;
                 display: block;
-                // margin: 1rem 0;
                 border-radius: 10px;
                 padding: 0.5rem 1rem;
                 background-color: v.$primary-dark;

--- a/client/components/AvailableChatRooms/AvailableChatRooms.module.scss
+++ b/client/components/AvailableChatRooms/AvailableChatRooms.module.scss
@@ -1,23 +1,39 @@
 @use "variables.module.scss" as v;
 
+
+// h2 {
+//     font-size: v.$base-font-size;
+//     text-align: center;
+//     color: v.$primary-dark;
+//     margin-bottom: 1rem;
+// }
+
+// a {
+//     text-decoration: none;
+//     color: v.$neutral-900;
+// }
+
 .wrapper {
+    text-align: center;
     
-    padding: 1rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center; 
-
-    h2 {
-        font-size: v.$base-font-size;
-        text-align: center;
-        color: v.$primary-dark;
-        margin-bottom: 1rem;
-    }
-
     a {
-        text-decoration: none;
-        color: v.$neutral-900;
+    text-decoration: none;
+    color: v.$neutral-900;
     }
+ 
+    .seeChatRoomsBtn {
+        color: v.$neutral-100;
+        display: block;
+        border: none;
+        border-radius: 10px;
+        padding: 0.5rem 1rem;
+        background-color: v.$primary-dark;
+
+        &:hover {
+            background-color: v.$primary-light;
+        }
+    }
+    
 
     .listWrapper {
         background-color: v.$neutral-100;
@@ -26,15 +42,20 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        padding-bottom: 1rem;;
-
+        max-width: 400px;
+        margin: 0 auto;
+        padding: 0 1rem;
+    
         ul {
             list-style-type: none;
             padding: 1rem;
-            max-height: 350px;
-            overflow: scroll;
+            max-width: 350px;
+            max-height: 300px;
+            overflow-y: scroll;
+            margin: 0;
             margin-bottom: 1rem;
-
+            width: 100%;
+    
             .roomInfo {
                 padding: 1rem;
                 background-color: v.$neutral-200;
@@ -43,31 +64,56 @@
                 margin-top: 0.5rem;
                 
                 &:hover {
-                    background-color: v.$neutral-300;
+                    box-shadow: 0px 0px 10px v.$neutral-500;
                 }
             }
         }
+        
+        .buttonContainer {
+            display: flex;
+            gap: 2rem;
+            margin-bottom: 1rem;
 
-        .createChatLink {
-            color: v.$neutral-100;
-            margin: 1rem 0;
-            border-radius: 10px;
-            padding: 0.5rem 1rem;
-            background-color: v.$primary-dark;
+            button {
+               color: v.$primary-dark;
+               background-color: v.$neutral-100;
+               border: 2px solid v.$primary-dark;
+               border-radius: 10px;
+               padding: 0.5rem 1rem;
 
-            &:hover {
-                background-color: v.$primary-light;
+               &:hover {
+                font-weight: bold;
+               }
+            }
+
+            .createChatLink {
+                color: v.$neutral-100;
+                display: block;
+                // margin: 1rem 0;
+                border-radius: 10px;
+                padding: 0.5rem 1rem;
+                background-color: v.$primary-dark;
+    
+                &:hover {
+                    background-color: v.$primary-light;
+                }
             }
         }
-    }
-
-    .homeLink {
-        color: v.$secondary;
-        margin-top: 1rem;
-
-        &:hover {
-            font-weight: bold;
+            
         }
-    }
+    
+        a.homeLink {
+            display: block;
+            color: v.$secondary;
+            margin-top: 2rem;
+    
+            &:hover {
+                font-weight: bold;
+            }
+        }
+
 
 }
+
+
+

--- a/client/components/AvailableChatRooms/AvailableChatRooms.tsx
+++ b/client/components/AvailableChatRooms/AvailableChatRooms.tsx
@@ -14,10 +14,10 @@ const AvailableChatRooms = (props: { user: UserDTO }) => {
   const username = props?.user?.username
 
   const [chatRooms, setChatRooms] = useState<string[]>([])
-  const [ showChatRoomList, setShowChatRoomList] = useState(false)
+  const [showChatRoomList, setShowChatRoomList] = useState(false)
 
   //first get the HubUrl based on what page we are on
-  const HubUrl = `chatHub`
+  // const HubUrl = `chatHub`
 
   //then use the useSignalR hook to connect to the Hub
   // const SignalRConnection = useSignalR(HubUrl)
@@ -25,7 +25,7 @@ const AvailableChatRooms = (props: { user: UserDTO }) => {
   const handleGetRooms = async () => {
     try {
       const connection = new HubConnectionBuilder()
-        .withUrl(`${process.env.NEXT_PUBLIC_HUB_URL}/${HubUrl}`, {
+        .withUrl(`${process.env.NEXT_PUBLIC_HUB_URL}`, {
           skipNegotiation: true,
           transport: HttpTransportType.WebSockets,
           accessTokenFactory: () => { 
@@ -53,7 +53,7 @@ const AvailableChatRooms = (props: { user: UserDTO }) => {
         <ul>
           {chatRooms.map((room: string, index: number) => (
             <li key={index} className={styles.roomInfo}>
-              {room}
+              <Link href={`/chat-room/${room}`}>{room}</Link>
             </li>
           ))}
         </ul>
@@ -74,16 +74,13 @@ const AvailableChatRooms = (props: { user: UserDTO }) => {
           <button onClick={handleGetRooms} className={styles.seeChatRoomsBtn}>
             See Available Rooms
           </button>}
-      {showChatRoomList && <CreateChatRoomList />}
-      <Link href="/" className={styles.homeLink}>
-        Home
-      </Link>
+        {showChatRoomList && <CreateChatRoomList />}
+        <Link href="/" className={styles.homeLink}>
+          Home
+        </Link>
       </div>
-
     </div>
   )
 }
-
-
 
 export default withAuth(AvailableChatRooms)

--- a/client/components/AvailableChatRooms/AvailableChatRooms.tsx
+++ b/client/components/AvailableChatRooms/AvailableChatRooms.tsx
@@ -1,105 +1,89 @@
 'use client'
-import React, { useEffect, useState } from 'react'
+import React, {  useState } from 'react'
 import styles from './AvailableChatRooms.module.scss'
-import chatRooms from './mockData.json'
 import Link from 'next/link'
 import type { ChatRoom } from 'types/data'
 import withAuth from 'hooks/WithAuth'
 import { UserDTO } from 'services/authentication/types/authentication.type'
-import type { HubConnection } from '@microsoft/signalr'
-import useSignalR from '@functions/useSignalR'
+import { ReadTokensFromLocalStorage } from 'services/authentication/authentication.service'
+import { HubConnectionBuilder, HttpTransportType } from '@microsoft/signalr'
 
-type chatRooms = ChatRoom[]
+// type chatRooms = ChatRoom[]
 
 const AvailableChatRooms = (props: { user: UserDTO }) => {
-  const username = JSON.stringify(props?.user?.username)
-  // HubConnection.invoke('GetActiveChatRooms')
-  // connection.on("activeRoomsMessage")
+  const username = props?.user?.username
 
   const [chatRooms, setChatRooms] = useState<string[]>([])
+  const [ showChatRoomList, setShowChatRoomList] = useState(false)
 
   //first get the HubUrl based on what page we are on
   const HubUrl = `chatHub`
 
   //then use the useSignalR hook to connect to the Hub
-  const SignalRConnection = useSignalR(HubUrl)
-  
-  
+  // const SignalRConnection = useSignalR(HubUrl)
 
-  // useEffect(() => {
-  //   if (!SignalRConnection) {
-  //     console.log('SignalRConnection is undefined')
-  //     return
-  //   }
-  //   const rooms = SignalRConnection.invoke('GetActiveChatRooms')
-  //   console.log('rooms: ', rooms)
-  //   // SignalRConnection.on('activeRoomsMessage', (room: string) => {
-  //   //   console.log('rooms: ', room)
-  //   //   setChatRooms([...chatRooms, room])
-  //   // })
-  // }, [chatRooms])
+  const handleGetRooms = async () => {
+    try {
+      const connection = new HubConnectionBuilder()
+        .withUrl(`${process.env.NEXT_PUBLIC_HUB_URL}/${HubUrl}`, {
+          skipNegotiation: true,
+          transport: HttpTransportType.WebSockets,
+          accessTokenFactory: () => { 
+            return ReadTokensFromLocalStorage().accessToken ?? ''
+          }
+        })
+        .build()
 
-  console.log('chat rooms: ', chatRooms)
+      await connection.start()
+
+      connection.invoke('GetActiveChatRooms')
+      connection.on('activeRoomsMessage', (chatRoomList) => {
+        console.log('chatRoomList: ', chatRoomList)
+        setChatRooms([...chatRoomList])
+        setShowChatRoomList(true)
+      })
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  const CreateChatRoomList = () => {
+    return (
+      <div className={styles.listWrapper}>
+        <ul>
+          {chatRooms.map((room: string, index: number) => (
+            <li key={index} className={styles.roomInfo}>
+              {room}
+            </li>
+          ))}
+        </ul>
+        <div className={styles.buttonContainer}>
+          <Link href="/createChat" className={styles.createChatLink}>
+            Create Chat Room
+          </Link>
+          <button onClick={() => setShowChatRoomList(false)}>Cancel</button>
+        </div>
+      </div>
+    )
+}
 
   return (
-    <div className={styles.wrapper}>
-      <h2>Available Chat Rooms</h2>
-      <p>{`Hi, ${username}. Please choose a room to join`}</p>
-      <div className={styles.listWrapper}>
-        {/* <ChatRoomList /> */}
-        <Link href="/createChat" className={styles.createChatLink}>
-          Create Chat Room
-        </Link>
-      </div>
+    <div>
+      <div className={styles.wrapper}>
+        {!showChatRoomList &&
+          <button onClick={handleGetRooms} className={styles.seeChatRoomsBtn}>
+            See Available Rooms
+          </button>}
+      {showChatRoomList && <CreateChatRoomList />}
       <Link href="/" className={styles.homeLink}>
         Home
       </Link>
+      </div>
+
     </div>
   )
 }
 
-// function ChatRoomList() {
-//   // HubConnection.invoke('GetActiveChatRooms')
-//   // connection.on("activeRoomsMessage")
-
-//   const [chatRooms, setChatRooms] = useState<string[]>([])
-
-//   //first get the HubUrl based on what page we are on
-//   const HubUrl = `chatHub`
-
-//   //then use the useSignalR hook to connect to the Hub
-//   const SignalRConnection = useSignalR(HubUrl)
-
-//   useEffect(() => {
-//     if (!SignalRConnection) {
-//       console.log('SignalRConnection is undefined')
-//       return
-//     }
-//     SignalRConnection.invoke('GetActiveChatRooms')
-//     SignalRConnection.on("activeRoomsMessage", (message: string) => {
-//       setChatRooms([...chatRooms, message])
-//     })
-//   }, [chatRooms])
-//   console.log(chatRooms)
-
-//   return (
-//     <ul>
-//       {chatRooms.map((room, index) => (
-//         <li key={index}>{room}</li>
-//       ))}
-//     </ul>
-//     // room.isActive && (
-//     //   <li key={room.creatorId}>
-//     //     <Link href={`/chat-room/${room.creatorId}`}>
-//     //       <div className={styles.roomInfo}>
-//     //         <h3>{room.name}</h3>
-//     //         <p>{room.description}</p>
-//     //       </div>
-//     //     </Link>
-//     //   </li>
-//     // )
-//    )
-// }
 
 
 export default withAuth(AvailableChatRooms)

--- a/client/components/AvailableChatRooms/AvailableChatRooms.tsx
+++ b/client/components/AvailableChatRooms/AvailableChatRooms.tsx
@@ -13,12 +13,40 @@ type chatRooms = ChatRoom[]
 
 const AvailableChatRooms = (props: { user: UserDTO }) => {
   const username = JSON.stringify(props?.user?.username)
+  // HubConnection.invoke('GetActiveChatRooms')
+  // connection.on("activeRoomsMessage")
+
+  const [chatRooms, setChatRooms] = useState<string[]>([])
+
+  //first get the HubUrl based on what page we are on
+  const HubUrl = `chatHub`
+
+  //then use the useSignalR hook to connect to the Hub
+  const SignalRConnection = useSignalR(HubUrl)
+  
+  
+
+  // useEffect(() => {
+  //   if (!SignalRConnection) {
+  //     console.log('SignalRConnection is undefined')
+  //     return
+  //   }
+  //   const rooms = SignalRConnection.invoke('GetActiveChatRooms')
+  //   console.log('rooms: ', rooms)
+  //   // SignalRConnection.on('activeRoomsMessage', (room: string) => {
+  //   //   console.log('rooms: ', room)
+  //   //   setChatRooms([...chatRooms, room])
+  //   // })
+  // }, [chatRooms])
+
+  console.log('chat rooms: ', chatRooms)
+
   return (
     <div className={styles.wrapper}>
       <h2>Available Chat Rooms</h2>
       <p>{`Hi, ${username}. Please choose a room to join`}</p>
       <div className={styles.listWrapper}>
-        <ChatRoomList />
+        {/* <ChatRoomList /> */}
         <Link href="/createChat" className={styles.createChatLink}>
           Create Chat Room
         </Link>
@@ -30,48 +58,48 @@ const AvailableChatRooms = (props: { user: UserDTO }) => {
   )
 }
 
-function ChatRoomList() {
-  // HubConnection.invoke('GetActiveChatRooms')
-  // connection.on("activeRoomsMessage")
+// function ChatRoomList() {
+//   // HubConnection.invoke('GetActiveChatRooms')
+//   // connection.on("activeRoomsMessage")
 
-  const [chatRooms, setChatRooms] = useState<string[]>([])
+//   const [chatRooms, setChatRooms] = useState<string[]>([])
 
-  //first get the HubUrl based on what page we are on
-  const HubUrl = `${process.env.NEXT_PUBLIC_HUB_URL}`
+//   //first get the HubUrl based on what page we are on
+//   const HubUrl = `chatHub`
 
-  //then use the useSignalR hook to connect to the Hub
-  const SignalRConnection = useSignalR(HubUrl)
+//   //then use the useSignalR hook to connect to the Hub
+//   const SignalRConnection = useSignalR(HubUrl)
 
-  useEffect(() => {
-    if (!SignalRConnection) {
-      console.log('SignalRConnection is undefined')
-      return
-    }
-    SignalRConnection.invoke('GetActiveChatRooms')
-    SignalRConnection.on("activeRoomsMessage", (message: string) => {
-      setChatRooms([...chatRooms, message])
-    })
-  }, [chatRooms])
+//   useEffect(() => {
+//     if (!SignalRConnection) {
+//       console.log('SignalRConnection is undefined')
+//       return
+//     }
+//     SignalRConnection.invoke('GetActiveChatRooms')
+//     SignalRConnection.on("activeRoomsMessage", (message: string) => {
+//       setChatRooms([...chatRooms, message])
+//     })
+//   }, [chatRooms])
+//   console.log(chatRooms)
 
-
-  return (
-    <ul>
-      {chatRooms.map((room, index) => (
-        <li key={index}>{room}</li>
-      ))}
-    </ul>
-    // room.isActive && (
-    //   <li key={room.creatorId}>
-    //     <Link href={`/chat-room/${room.creatorId}`}>
-    //       <div className={styles.roomInfo}>
-    //         <h3>{room.name}</h3>
-    //         <p>{room.description}</p>
-    //       </div>
-    //     </Link>
-    //   </li>
-    // )
-   )
-}
+//   return (
+//     <ul>
+//       {chatRooms.map((room, index) => (
+//         <li key={index}>{room}</li>
+//       ))}
+//     </ul>
+//     // room.isActive && (
+//     //   <li key={room.creatorId}>
+//     //     <Link href={`/chat-room/${room.creatorId}`}>
+//     //       <div className={styles.roomInfo}>
+//     //         <h3>{room.name}</h3>
+//     //         <p>{room.description}</p>
+//     //       </div>
+//     //     </Link>
+//     //   </li>
+//     // )
+//    )
+// }
 
 
 export default withAuth(AvailableChatRooms)

--- a/client/components/LoginAndRegisterHandler/Login/LoginForm.tsx
+++ b/client/components/LoginAndRegisterHandler/Login/LoginForm.tsx
@@ -32,7 +32,7 @@ const LoginForm = () => {
 
   useEffect(() => {
     if (loggedInUser && loggedInUser.username) {
-      router.push('/chat-room')
+      router.push('/profile')
     }
   })
 

--- a/client/components/LoginAndRegisterHandler/Register/RegisterForm.tsx
+++ b/client/components/LoginAndRegisterHandler/Register/RegisterForm.tsx
@@ -38,7 +38,7 @@ const RegisterForm = () => {
   const router = useRouter()
   useEffect(() => {
     if (loggedInUser && loggedInUser.username) {
-      router.push('/chat-room')
+      router.push('/profile')
     }
   })
 

--- a/client/functions/useSignalR.ts
+++ b/client/functions/useSignalR.ts
@@ -6,10 +6,7 @@ import {
   HubConnectionBuilder,
   HubConnectionState,
   LogLevel,
-  HttpTransportType
 } from '@microsoft/signalr'
-import { ReadTokensFromLocalStorage } from 'services/authentication/authentication.service'
-
 
 export interface SignalRConnectionOptions {
   logLevel?: LogLevel
@@ -26,18 +23,8 @@ const useSignalR = (hubName: string, options?: SignalRConnectionOptions) => {
 
   useEffect(() => {
     if (hubName === '') return
-    // const connection = new HubConnectionBuilder()
-    //   .withUrl(`/hubs/${hubName}`, options || {})
-    //   .build()
-
     const connection = new HubConnectionBuilder()
-      .withUrl(`${process.env.NEXT_PUBLIC_HUB_URL}/${hubName}`, {
-        skipNegotiation: true,
-        transport: HttpTransportType.WebSockets,
-        accessTokenFactory: () => { 
-          return ReadTokensFromLocalStorage().accessToken ?? ''
-        }
-      })
+      .withUrl(`/hubs/${hubName}`, options || {})
       .build()
 
     connectionRef.current = connection

--- a/client/functions/useSignalR.ts
+++ b/client/functions/useSignalR.ts
@@ -6,7 +6,10 @@ import {
   HubConnectionBuilder,
   HubConnectionState,
   LogLevel,
+  HttpTransportType
 } from '@microsoft/signalr'
+import { ReadTokensFromLocalStorage } from 'services/authentication/authentication.service'
+
 
 export interface SignalRConnectionOptions {
   logLevel?: LogLevel
@@ -23,15 +26,25 @@ const useSignalR = (hubName: string, options?: SignalRConnectionOptions) => {
 
   useEffect(() => {
     if (hubName === '') return
+    // const connection = new HubConnectionBuilder()
+    //   .withUrl(`/hubs/${hubName}`, options || {})
+    //   .build()
+
     const connection = new HubConnectionBuilder()
-      .withUrl(`/hubs/${hubName}`, options || {})
+      .withUrl(`${process.env.NEXT_PUBLIC_HUB_URL}/${hubName}`, {
+        skipNegotiation: true,
+        transport: HttpTransportType.WebSockets,
+        accessTokenFactory: () => { 
+          return ReadTokensFromLocalStorage().accessToken ?? ''
+        }
+      })
       .build()
 
     connectionRef.current = connection
 
-    return () => {
-      connection.stop()
-    }
+    // return () => {
+    //   connection.stop()
+    // }
   }, [hubName, options])
 
   useEffect(() => {


### PR DESCRIPTION
- Currently, if user is clicks on 'Login' or 'Register' from the home page, they are taken to the corresponding form. If the user is logged in, they are redirected to /profile.
- This component is rendered on the /profile page. 
- When the user clicks a button to "See Available Rooms", they are shown the current chat rooms.
- When the user clicks on a room in the list, it links them to /chat-room/[slug], where [slug] is equal to the name of the room.
